### PR TITLE
Emoji support (Atomic change)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ sync-db:
 	docker-compose up -d mysql; \
 	ssh epix "docker exec mysql bash -c 'mysqldump -u root --password=\$$MYSQL_ROOT_PASSWORD xrbrighton'" > xrbrighton.sql; \
 	docker-compose exec mysql bash -c 'mysql -u root --password=$$MYSQL_ROOT_PASSWORD -e "DROP DATABASE xrbrighton;"'; \
-	docker-compose exec mysql bash -c 'mysql -u root --password=$$MYSQL_ROOT_PASSWORD -e "CREATE DATABASE xrbrighton;"'; \
+	docker-compose exec mysql bash -c 'mysql -u root --password=$$MYSQL_ROOT_PASSWORD -e "CREATE DATABASE xrbrighton CHARACTER SET utf8mb4_unicode_ci;"'; \
 	docker cp xrbrighton.sql xr-brighton-mysql:/tmp/; \
 	docker exec xr-brighton-mysql bash -c 'mysql -u root --password=$$MYSQL_ROOT_PASSWORD xrbrighton < /tmp/xrbrighton.sql'; \
 	docker exec xr-brighton-mysql bash -c 'rm /tmp/xrbrighton.sql'; \

--- a/project/settings.py
+++ b/project/settings.py
@@ -193,6 +193,7 @@ if os.environ.get('MYSQL_DATABASE'):
             'PASSWORD': os.environ.get('MYSQL_PASSWORD', ''),
             'HOST': os.environ.get('MYSQL_HOST', 'localhost'),
             'PORT': '',
+            'OPTIONS': 'utf8mb4'
         }
     }
 else:


### PR DESCRIPTION
Currently Django will throw errors when creating posts which include emojis. 

This change updates the Django Config to choose the MB4 Unicode character set, as well as adjusts the creation to set this at startup.

Adapted from this [blog post](http://blog.manbolo.com/2014/03/31/using-emojis-in-django-model-fields). Docker compose needs testing, but the setting of the character setting on after deployment is tested working.

Procedure:

1. Login to database,
2. Set Character set for DB,
3. Convert targeted column in table, e.g. description in `project_article`. 
4. Restart app
5. Add emojis to event articles!

Example:
```
mysql> show columns from project_event;
mysql> ALTER TABLE project_event CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
mysql> ALTER TABLE project_event CHANGE description description LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
```

Hope this was helpful!
